### PR TITLE
Fix license typo

### DIFF
--- a/MonitorTool/setup/license/license.txt
+++ b/MonitorTool/setup/license/license.txt
@@ -24,7 +24,7 @@ NO WARRANTY. ANY USE BY LICENSEE IS AT THE LICENSEE'S OWN RISK. PRODUCT IS PROVI
 
 USAGE STATISTICS
 This version is a beta version. We want to improve this software.
-You allow us to collect anonymous usage statistics to help us to provide a better quality product. The information collected is not used to identify or contact you. The monitortool connect to a update server to get new updates and send protokollfiles,data and anonymous user information to this server.  If you set a valid email adress in file/config/emailadress this email adress is sent to the server. This email can be used to give you additional information for product improvement and other documentation. If you dont want this email-service you can leave this field empty. 
+You allow us to collect anonymous usage statistics to help us to provide a better quality product. The information collected is not used to identify or contact you. The monitortool connect to a update server to get new updates and send protokollfiles,data and anonymous user information to this server.  If you set a valid email address in file/config/emailadress this email address is sent to the server. This email can be used to give you additional information for product improvement and other documentation. If you dont want this email-service you can leave this field empty. 
 This software modify data in the metatrader directorys. Some information will be send anonymous to the update server.
 All information who was sent to the updateserver will only used to improve the monitortool and not given to a third person.
 


### PR DESCRIPTION
## Summary
- correct 'email adress' typos in license.txt

## Testing
- `grep -n address MonitorTool/setup/license/license.txt`


------
https://chatgpt.com/codex/tasks/task_e_68590fe23278832aba4d3cd9ae0da043